### PR TITLE
Added Dockerfile to generate a small docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+data/*
+cowyo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# First build step
+FROM golang:1.9-alpine as builder
+
+WORKDIR /go/src/cowyo
+COPY . .
+# Disable crosscompiling
+ENV CGO_ENABLED=0
+
+# Install git and make, compile and cleanup
+RUN apk add --no-cache git make \
+	&& go get -u github.com/schollz/cowyo \
+    && go get -u github.com/jteeuwen/go-bindata/... \
+    && make \
+    && apk del --purge git make \
+    && rm -rf /var/cache/apk*
+
+# Second build step uses the minimal scratch Docker image
+FROM scratch
+# Copy the binary from the first step
+COPY --from=builder /go/src/cowyo/cowyo /usr/local/bin/cowyo
+# Expose data folder
+VOLUME /data
+EXPOSE 8050
+# Start cowyo listening on any host
+CMD ["cowyo", "--host", "0.0.0.0"]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # make -j4 release
 
 VERSION=$(shell git describe)
-LDFLAGS=-ldflags "-s -w -X main.version=${VERSION}"
+LDFLAGS=-ldflags "-s -w -X main.version=${VERSION}" -a -installsuffix cgo
 
 .PHONY: build
 build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+services:
+  cowyo:
+    build: .
+    ports:
+      - 8050:8050
+    volumes:
+      - ./data:/data


### PR DESCRIPTION
Requested on issue #83. Docker image weighs around 11MB. It uses the same build process found on `.travis.yml`.

After building, the container can be run like this:

`docker run --name cowyo -p 8050:8050 cowyo`