### PR TITLE
Lock page with respect to session

### DIFF
--- a/page.go
+++ b/page.go
@@ -26,6 +26,7 @@ type Page struct {
 	IsEncrypted             bool
 	IsPrimedForSelfDestruct bool
 	IsPublished             bool
+	UnlockedFor             string
 }
 
 func (p Page) LastEditTime() time.Time {


### PR DESCRIPTION
Introduce per-session (per-user) unlocking as discussed in #110 

Now when unlocking a page then the is unlocked only for the user who actually unlocked it. It is implemented by adding "UnlockedFor" attribute to Page struct and fill it with randomly generated "sid" stored in a session storage.

Comments are welcome!